### PR TITLE
33 amount of ingridients

### DIFF
--- a/src/main/java/com/mealapp/experiment/model/IngredientMeal.java
+++ b/src/main/java/com/mealapp/experiment/model/IngredientMeal.java
@@ -27,8 +27,8 @@ public class IngredientMeal {
     @JoinColumn(name = "ingredient_id", nullable = false)
     private Ingredient ingredient;
 
-    @Column(name = "quantity")
-    private double quantity;
+    @Column(name = "amount")
+    private double amount;
 
     @Column(name = "unit")
     private String unit;

--- a/src/main/java/com/mealapp/experiment/model/IngredientMeal.java
+++ b/src/main/java/com/mealapp/experiment/model/IngredientMeal.java
@@ -1,0 +1,35 @@
+package com.mealapp.experiment.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "ingredient_meal")
+public class IngredientMeal {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "meal_id", nullable = false)
+    @JsonIgnore
+    private Meal meal;
+
+    @ManyToOne
+    @JoinColumn(name = "ingredient_id", nullable = false)
+    private Ingredient ingredient;
+
+    @Column(name = "quantity")
+    private double quantity;
+
+    @Column(name = "unit")
+    private String unit;
+}

--- a/src/main/java/com/mealapp/experiment/model/Meal.java
+++ b/src/main/java/com/mealapp/experiment/model/Meal.java
@@ -32,7 +32,7 @@ public class Meal {
     @Column(name = "calories")
     private Integer calories;
 
-    @Column(name = "prep_Time")
+    @Column(name = "prep_time")
     private Integer prepTime;
 
     @Column(name = "picture")
@@ -45,13 +45,8 @@ public class Meal {
     @JoinColumn(name = "diet_id", nullable = false)
     private Diet diet;
 
-    @ManyToMany
-    @JoinTable(
-            name = "ingredient_meal",
-            joinColumns = @JoinColumn(name = "meal_id"),
-            inverseJoinColumns = @JoinColumn(name = "ingredient_id")
-    )
-    private Set<Ingredient> ingredients = new HashSet<>();
+    @OneToMany(fetch = FetchType.LAZY)
+    private Set<IngredientMeal> ingredientMeals = new HashSet<>();
 
     @ManyToMany
     @JoinTable(

--- a/src/main/java/com/mealapp/experiment/model/Meal.java
+++ b/src/main/java/com/mealapp/experiment/model/Meal.java
@@ -45,7 +45,7 @@ public class Meal {
     @JoinColumn(name = "diet_id", nullable = false)
     private Diet diet;
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "meal", fetch = FetchType.LAZY)
     private Set<IngredientMeal> ingredientMeals = new HashSet<>();
 
     @ManyToMany

--- a/src/main/java/com/mealapp/experiment/repository/MealRepository.java
+++ b/src/main/java/com/mealapp/experiment/repository/MealRepository.java
@@ -16,6 +16,12 @@ public interface MealRepository extends JpaRepository<Meal, Long> {
     @Query("SELECT DISTINCT m FROM Meal m JOIN m.categories c WHERE m.diet.id = :dietId AND (:categoryIds IS NULL OR c.id IN :categoryIds)")
     List<Meal> findByDietIdAndCategoriesIds(@Param("dietId") Long dietId, @Param("categoryIds") List<Long> categoryIds);
 
-    @EntityGraph(attributePaths = {"ingredients", "ingredients.allergies", "categories", "diet"})
-    Optional<Meal> findAllById(Long id);
+    @EntityGraph(attributePaths = {
+            "ingredientMeals",
+            "ingredientMeals.ingredient",
+            "ingredientMeals.ingredient.allergies",
+            "categories",
+            "diet"
+    })
+    Optional<Meal> findMealById(Long id);
 }

--- a/src/main/java/com/mealapp/experiment/service/meal/MealServiceImp.java
+++ b/src/main/java/com/mealapp/experiment/service/meal/MealServiceImp.java
@@ -6,6 +6,7 @@ import com.mealapp.experiment.service.utils.ServiceMapper;
 import com.mealapp.experiment.common.utils.ExceptionUtils;
 import com.mealapp.openapi.meal.model.ListMealResponse;
 import com.mealapp.openapi.meal.model.ReadMealResponse;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -22,37 +23,40 @@ public class MealServiceImp implements MealService {
     private final ServiceMapper mapper;
 
     @Override
+    @Transactional(readOnly = true)
     public ReadMealResponse getMeal(Long id) {
-
-        Meal meal = mealRepository.findAllById(id).orElseThrow(ExceptionUtils.exception(HttpStatus.NOT_FOUND, "Not found meal with id: " + id));
+        Meal meal = mealRepository.findMealById(id).orElseThrow(ExceptionUtils.exception(HttpStatus.NOT_FOUND, "Not found meal with id: " + id));
         return mapper.mealToReadMealResponse(meal);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<ListMealResponse> listMeals(Long dietId, List<Long> categoryIdList) {
         return mapper.mealToListMealResponse(mealRepository.findByDietIdAndCategoriesIds(dietId, categoryIdList));
     }
 
     @Override
+    @Transactional
     public ReadMealResponse createMeal(Meal createMealRequest) {
         log.info("Creating new meal with name: {}", createMealRequest.getName());
         Meal savedMeal = mealRepository.save(createMealRequest);
 
-        Meal mealWithAllergies = mealRepository.findAllById(savedMeal.getId())
+        Meal mealWithAllergies = mealRepository.findMealById(savedMeal.getId())
                 .orElseThrow(() -> new RuntimeException("Failed to retrieve saved meal"));
 
         return mapper.mealToReadMealResponse(mealWithAllergies);
     }
 
     @Override
+    @Transactional
     public ReadMealResponse updateMeal(Long id, Meal updateMealRequest) {
         log.info("Updating meal with id: {}", id);
 
-        Meal existingMeal = mealRepository.findAllById(id)
+        Meal existingMeal = mealRepository.findMealById(id)
                 .orElseThrow(ExceptionUtils.exception(HttpStatus.NOT_FOUND, "Not found meal with id: " + id));
 
         mapper.merge(updateMealRequest, existingMeal);
-        Meal mealWithAllergies = mealRepository.findAllById(existingMeal.getId())
+        Meal mealWithAllergies = mealRepository.findMealById(existingMeal.getId())
                 .orElseThrow(() -> new RuntimeException("Failed to retrieve updated meal"));
 
         return mapper.mealToReadMealResponse(mealWithAllergies);

--- a/src/main/java/com/mealapp/experiment/service/utils/ServiceMapper.java
+++ b/src/main/java/com/mealapp/experiment/service/utils/ServiceMapper.java
@@ -6,6 +6,7 @@ import com.mealapp.experiment.model.IngredientMeal;
 import com.mealapp.experiment.model.Meal;
 import com.mealapp.openapi.diet.model.ListDietResponse;
 import com.mealapp.openapi.meal.model.AllergyObject;
+import com.mealapp.openapi.meal.model.IngredientObject;
 import com.mealapp.openapi.meal.model.ListMealResponse;
 import com.mealapp.openapi.meal.model.ReadMealResponse;
 import org.mapstruct.Mapper;
@@ -31,6 +32,7 @@ import java.util.stream.Stream;
 public interface ServiceMapper {
 
     @Mapping(target = "allergies", source = "ingredientMeals", qualifiedByName = "extractAllergies")
+    @Mapping(target = "ingredients", source = "ingredientMeals", qualifiedByName = "extractIngredients")
     ReadMealResponse mealToReadMealResponse(Meal meal);
 
     ListMealResponse mealToListMealResponse(Meal meal);
@@ -42,6 +44,28 @@ public interface ServiceMapper {
     Meal merge(Meal newMeal, @MappingTarget Meal existingMeal);
 
     List<ListDietResponse> dietToListDietResponse(List<Diet> dietList);
+
+    @Named("extractIngredients")
+    default List<IngredientObject> extractIngredients(Set<IngredientMeal> ingredientMeals) {
+        if (ingredientMeals == null || ingredientMeals.isEmpty()) {
+            return List.of();
+        }
+        return ingredientMeals.stream()
+                .filter(Objects::nonNull)
+                .map(im -> {
+                    if (im.getIngredient() == null) {
+                        return null;
+                    }
+                    IngredientObject ingredientObject = new IngredientObject();
+                    ingredientObject.setId(im.getIngredient().getId());
+                    ingredientObject.setName(im.getIngredient().getName());
+                    ingredientObject.setAmount(im.getAmount());
+                    ingredientObject.setUnit(im.getUnit());
+                    return ingredientObject;
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
 
     @Named("extractAllergies")
     default List<AllergyObject> extractAllergies(Set<IngredientMeal> ingredientMeals) {

--- a/src/main/java/com/mealapp/experiment/service/utils/ServiceMapper.java
+++ b/src/main/java/com/mealapp/experiment/service/utils/ServiceMapper.java
@@ -56,12 +56,12 @@ public interface ServiceMapper {
                     if (im.getIngredient() == null) {
                         return null;
                     }
-                    IngredientObject ingredientObject = new IngredientObject();
-                    ingredientObject.setId(im.getIngredient().getId());
-                    ingredientObject.setName(im.getIngredient().getName());
-                    ingredientObject.setAmount(im.getAmount());
-                    ingredientObject.setUnit(im.getUnit());
-                    return ingredientObject;
+                    IngredientObject ingredient = new IngredientObject();
+                    ingredient.setId(im.getIngredient().getId());
+                    ingredient.setName(im.getIngredient().getName());
+                    ingredient.setAmount(im.getAmount());
+                    ingredient.setUnit(im.getUnit());
+                    return ingredient;
                 })
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
@@ -69,22 +69,13 @@ public interface ServiceMapper {
 
     @Named("extractAllergies")
     default List<AllergyObject> extractAllergies(Set<IngredientMeal> ingredientMeals) {
-        if (ingredientMeals == null || ingredientMeals.isEmpty()) {
-            return List.of();
-        }
+        if (ingredientMeals == null || ingredientMeals.isEmpty()) return List.of();
         return ingredientMeals.stream()
+                .map(IngredientMeal::getIngredient)
                 .filter(Objects::nonNull)
-                .flatMap(im -> {
-                    if (im.getIngredient() == null) {
-                        return Stream.<Allergy>empty();
-                    }
-                    var allergies = im.getIngredient().getAllergies();
-                    if (allergies == null || allergies.isEmpty()) {
-                        return Stream.<Allergy>empty();
-                    }else {
-                        return allergies.stream();
-                    }
-                })
+                .flatMap(ingredient -> ingredient.getAllergies() == null
+                        ? Stream.empty()
+                        : ingredient.getAllergies().stream())
                 .distinct()
                 .map(this::allergyToAllergyObject)
                 .collect(Collectors.toList());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.profiles.active=local
 
 # JPA
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=true
 spring.jpa.open-in-view=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.profiles.active=local
 
 # JPA
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=true
 spring.jpa.open-in-view=false

--- a/src/main/resources/openapi/common/schemas.yaml
+++ b/src/main/resources/openapi/common/schemas.yaml
@@ -60,3 +60,18 @@ components:
       maximum: 99999.99
       description: Nutritional value per 100g
       example: 25.5
+    Amount:
+      type: number
+      format: double
+      description: Amount of the item in grams.
+      minimum: 0.1
+      maximum: 9999.99
+      default: 1.0
+      example: 150.0
+    Unit:
+      type: string
+      description: Unit of measurement for the amount.
+      maxLength: 10
+      default: g
+      example: g
+

--- a/src/main/resources/openapi/meal.yaml
+++ b/src/main/resources/openapi/meal.yaml
@@ -249,6 +249,10 @@ components:
           $ref: 'common/schemas.yaml#/components/schemas/Id'
         name:
           $ref: 'common/schemas.yaml#/components/schemas/Name'
+        amount:
+          $ref: 'common/schemas.yaml#/components/schemas/Amount'
+        unit:
+            $ref: 'common/schemas.yaml#/components/schemas/Unit'
     AllergyObject:
       type: object
       properties:


### PR DESCRIPTION
This pull request refactors how meals and their ingredients are related in the backend, moving from a direct many-to-many relationship to an explicit join entity, `IngredientMeal`, which allows storing additional information (such as amount and unit) for each ingredient in a meal. It also updates the service, repository, and API schema to support this new structure.

**Core data model changes:**

* Introduced a new entity class `IngredientMeal` to represent the relationship between `Meal` and `Ingredient`, including `amount` and `unit` fields for each ingredient in a meal.
* Updated the `Meal` entity to replace the `ingredients` many-to-many relationship with a one-to-many relationship to `IngredientMeal`.

**Repository and service layer updates:**

* Modified `MealRepository` to use the new `ingredientMeals` relationship, updating the entity graph and method names accordingly (`findAllById` → `findMealById`).
* Updated `MealServiceImp` to use the new repository methods and added `@Transactional` annotations for consistency and performance.

**Mapping and DTO changes:**

* Updated `ServiceMapper` to map `ingredientMeals` to the response models, including logic to convert `IngredientMeal` entities into ingredient and allergy DTOs. [[1]](diffhunk://#diff-5522e1f397d285888dba25e4a7c5c8cb3ae27c8232f4505d3581a723f660e87aL31-R35) [[2]](diffhunk://#diff-5522e1f397d285888dba25e4a7c5c8cb3ae27c8232f4505d3581a723f660e87aL44-R78)

**API schema changes:**

* Added `amount` and `unit` fields to the ingredient object in the OpenAPI schema, and defined their types and constraints. [[1]](diffhunk://#diff-a121dfa3269b6e380a2f9f6245ea440f783c0de9738c6ba1441ef71211ec1318R63-R77) [[2]](diffhunk://#diff-879ad699a627e7f43e7e6111885a9528d3a0a9547b7b5d991c7903211223793cR252-R255)