### PR TITLE
Added servings to meal

### DIFF
--- a/src/main/java/com/mealapp/experiment/model/Meal.java
+++ b/src/main/java/com/mealapp/experiment/model/Meal.java
@@ -38,6 +38,9 @@ public class Meal {
     @Column(name = "picture")
     private String picture;
 
+    @Column(name = "servings")
+    private Integer servings;
+
     @Column(name = "date_created")
     private LocalDate createdDate;
 

--- a/src/main/resources/openapi/common/schemas.yaml
+++ b/src/main/resources/openapi/common/schemas.yaml
@@ -34,6 +34,13 @@ components:
       maxLength: 255
       description: Step by step instructions to prepare the item.
       example: Mix all ingredients and cook for 30 minutes.
+    Servings:
+      type: integer
+      description: Number of servings the recipe yields.
+      minimum: 1
+      maximum: 100
+      default: 4
+      example: 4
     PrepTime:
       type: integer
       description: Preparation time in minutes

--- a/src/main/resources/openapi/meal.yaml
+++ b/src/main/resources/openapi/meal.yaml
@@ -167,6 +167,8 @@ components:
           $ref: 'common/schemas.yaml#/components/schemas/Description'
         recipe:
           $ref: 'common/schemas.yaml#/components/schemas/Recipe'
+        servings:
+          $ref: 'common/schemas.yaml#/components/schemas/Servings'
         prepTime:
           $ref: 'common/schemas.yaml#/components/schemas/PrepTime'
         calories:


### PR DESCRIPTION
This pull request adds support for tracking the number of servings a meal yields throughout the backend model and API schema. The main changes introduce a new `servings` field to the `Meal` entity and update the OpenAPI specifications accordingly.

**Backend model update:**
- Added a new `servings` field of type `Integer` to the `Meal` class to store the number of servings for each meal.

**API schema updates:**

*OpenAPI common schemas:*
- Introduced a new `Servings` schema, defining it as an integer with constraints and documentation for use across API definitions.

*Meal API schema:*
- Added the `servings` property to the meal object by referencing the new `Servings` schema, ensuring it is part of the API contract.